### PR TITLE
Min score on duplicated items

### DIFF
--- a/fuse.js
+++ b/fuse.js
@@ -255,7 +255,7 @@
                         //console.log(bitapResult.score);
 
                         // Check if the item already exists in our results
-                        existingResult = rawResultsMap[index];
+                        existingResult = rawResults[index];
                         if (existingResult) {
                             // Use the lowest score
                             existingResult.score = Math.min(existingResult.score, bitapResult.score);


### PR DESCRIPTION
Found an error that prevented min score to be calculated when finding duplicated items, related to commit  https://github.com/krisk/Fuse/commit/1d5b0f994d4ccc6380947a97efa4fdbe2a3c3f53
