### PR TITLE
Options check for BitapSearcher

### DIFF
--- a/src/fuse.js
+++ b/src/fuse.js
@@ -36,7 +36,8 @@
    * you may not use this file except in compliance with the License.
    */
   var BitapSearcher = function(pattern, options) {
-    this.options = options || {};
+    options = options || {};
+    this.options = options;
     this.options.location = options.location || BitapSearcher.defaultOptions.location;
     this.options.distance = 'distance' in options ? options.distance : BitapSearcher.defaultOptions.distance;
     this.options.threshold = 'threshold' in options ? options.threshold : BitapSearcher.defaultOptions.threshold;


### PR DESCRIPTION
Fix to allow null or undefined options. The previous version had a check when setting this.options but left the variable untouched, so when trying to access eg `options.location` it through a type error.
