### PR TITLE
Added support for a ```getFn``` option that will be used to access object properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ The search function to use.  Note that the search function (`[[Function]]`) must
 
 ---
 
+**getFn** (*type*: `Function`, *default*: `Utils.deepValue`)
+
+The get function to use when fetching an objects properties.  The default will search nested paths *ie foo.bar.baz*
+
+```javascript
+/*
+@param obj The object being searched
+@param path The path to the target property
+*/
+
+// example using an object with a `getter` method
+getFn: function (obj, path) {
+  return obj.get(path);
+}
+```
+---
+
 **sortFn** (*type*: `Function`, *default*: `Array.prototype.sort`)
 
 The function that is used for sorting the result list.

--- a/src/fuse.js
+++ b/src/fuse.js
@@ -259,6 +259,7 @@
     this.options.searchFn = options.searchFn || Fuse.defaultOptions.searchFn,
     this.options.sortFn = options.sortFn || Fuse.defaultOptions.sortFn,
     this.options.keys = options.keys || Fuse.defaultOptions.keys;
+    this.options.getFn = options.getFn || Fuse.defaultOptions.getFn;
   };
 
   Fuse.defaultOptions = {
@@ -291,6 +292,9 @@
     sortFn: function(a, b) {
       return a.score - b.score;
     },
+
+    // Default get function
+    getFn: Utils.deepValue,
 
     keys: []
   };
@@ -367,7 +371,7 @@
         item = list[i];
         // Iterate over every key
         for (j = 0; j < searchKeysLen; j++) {
-          analyzeText(Utils.deepValue(item, searchKeys[j]), item, i);
+          analyzeText(this.options.getFn(item, searchKeys[j]), item, i);
         }
       }
     }

--- a/test/fuse-test.js
+++ b/test/fuse-test.js
@@ -156,6 +156,66 @@ vows.describe('Deep key search, with ["title", "author.firstName"]').addBatch({
   }
 }).export(module);
 
+vows.describe('Custom search function, with ["title", "author.firstName"]').addBatch({
+  'Deep:': {
+    topic: function() {
+      var books = [{
+        "title": "Old Man's War",
+        "author": {
+          "firstName": "John",
+          "lastName": "Scalzi"
+        }
+      }, {
+        "title": "The Lock Artist",
+        "author": {
+          "firstName": "Steve",
+          "lastName": "Hamilton"
+        }
+      }];
+      var options = {
+        keys: ["title", "author.firstName"],
+        getFn: function(obj, path) {
+          if (!obj) {
+            return null;
+          }
+          obj = obj.author.lastName;
+          return obj;
+        }
+      };
+      var fuse = new Fuse(books, options)
+      return fuse;
+    },
+    'When searching for the term "Hmlt"': {
+      topic: function(fuse) {
+        var result = fuse.search("Hmlt");
+        return result;
+      },
+      'we get a list of containing at least 1 item': function(result) {
+        assert.isTrue(result.length > 0);
+      },
+      'whose first value is found': function(result) {
+        assert.deepEqual(result[0], {
+          "title": "The Lock Artist",
+          "author": {
+            "firstName": "Steve",
+            "lastName": "Hamilton"
+          }
+        });
+      },
+    },
+    'When searching for the term "Stve"': {
+      topic: function(fuse) {
+        var result = fuse.search("Stve");
+        return result;
+      },
+      'we get a list of containing at least no items': function(result) {
+        // assert.isTrue(result.length > 0);
+        assert.equal(result.length, 0);
+      },
+    }
+  }
+}).export(module);
+
 vows.describe('Include score in result list: ["Apple", "Orange", "Banana"]').addBatch({
   'Options:': {
     topic: function() {


### PR DESCRIPTION
I did this a long time ago to support using Fuse with Ember objects, which more or less require the use of `obj.get('path')`.  Finally got around to bringing it up to pull request quality.
