### PR TITLE
Add public set function

### DIFF
--- a/src/fuse.js
+++ b/src/fuse.js
@@ -337,6 +337,18 @@
   };
 
   /**
+   * Sets a new list for Fuse to match against.
+   * @param {Array} list
+   * @return {Array} The newly set list
+   * @public
+   */
+  Fuse.prototype.set = function(list) {
+    this.list = list;
+
+    return list;
+  };
+
+  /**
    * Searches for all the items whose keys (fuzzy) match the pattern.
    * @param {String} pattern The pattern string to fuzzy search on.
    * @return {Array} A list of all serch matches.

--- a/test/fuse-test.js
+++ b/test/fuse-test.js
@@ -505,8 +505,33 @@ vows.describe('Searching by ID').addBatch({
         assert.equal(result.length, 1);
       },
       'whose value is the ISBN of the book': function(result) {
-        assert.isString(result[0])
+        assert.isString(result[0]);
         assert.equal(result[0], "B");
+      },
+    }
+  }
+}).export(module);
+
+vows.describe('Set new list on Fuse').addBatch({
+  'Options:': {
+    topic: function() {
+      var fruits = ["Apple", "Orange", "Banana"];
+      var vegetables = ["Onion", "Lettuce", "Broccoli"];
+
+      var fuse = new Fuse(fruits);
+      fuse.set(vegetables);
+      return fuse;
+    },
+    'When searching for the term "Apple"': {
+      topic: function(fuse) {
+        var result = fuse.search("Lettuce");
+        return result;
+      },
+      'we get a list of containing 1 item, which is an exact match': function(result) {
+        assert.equal(result.length, 1);
+      },
+      'whose value is the index 0, representing ["Lettuce"]': function(result) {
+        assert.equal(result[0], 1);
       },
     }
   }


### PR DESCRIPTION
This PR aims to add a public set function to Fuse so the internal list Fuse searches against can be changed without having to instantiate a whole new Fuse object each time. I thought this might also go well with krisk#46 but provide an extra option where you may not care about manipulating the actual list, and just want to declaratively set it to a given array of things.

Feel free to add comments or let me know what I can change to make it better.