### PR TITLE
Add semi-colon to the end of the function

### DIFF
--- a/src/fuse.js
+++ b/src/fuse.js
@@ -797,4 +797,4 @@
     global.Fuse = Fuse
   }
 
-})(this)
+})(this);


### PR DESCRIPTION
Adding a semi-colon to the end of the function.
Without it it's breaks when doing minify/uglify with more files.