### PR TITLE
Add type annotations for closure-compiler support

### DIFF
--- a/src/fuse.js
+++ b/src/fuse.js
@@ -20,8 +20,8 @@
 ;(function (global) {
   'use strict'
 
-  /** @param {...*} var_args */
-  function log (var_args) {
+  /** @type {function(...*)} */
+  function log () {
     console.log.apply(console, arguments)
   }
 

--- a/src/fuse.js
+++ b/src/fuse.js
@@ -20,7 +20,8 @@
 ;(function (global) {
   'use strict'
 
-  function log () {
+  /** @param {...*} var_args */
+  function log (var_args) {
     console.log.apply(console, arguments)
   }
 
@@ -83,6 +84,11 @@
     tokenSeparator: / +/g
   }
 
+  /**
+   * @constructor
+   * @param {!Array} list
+   * @param {!Object<string, *>} options
+   */
   function Fuse (list, options) {
     var i
     var len
@@ -92,15 +98,17 @@
     this.list = list
     this.options = options = options || {}
 
-    // Add boolean type options
-    for (i = 0, keys = ['sort', 'shouldSort', 'verbose', 'tokenize'], len = keys.length; i < len; i++) {
-      key = keys[i]
-      this.options[key] = key in options ? options[key] : defaultOptions[key]
-    }
-    // Add all other options
-    for (i = 0, keys = ['searchFn', 'sortFn', 'keys', 'getFn', 'include', 'tokenSeparator'], len = keys.length; i < len; i++) {
-      key = keys[i]
-      this.options[key] = options[key] || defaultOptions[key]
+    for (key in defaultOptions) {
+      if (!defaultOptions.hasOwnProperty(key)) {
+        continue;
+      }
+      // Add boolean type options
+      if (typeof defaultOptions[key] === 'boolean') {
+        this.options[key] = key in options ? options[key] : defaultOptions[key];
+      // Add all other options
+      } else {
+        this.options[key] = options[key] || defaultOptions[key]
+      }
     }
   }
 
@@ -108,8 +116,8 @@
 
   /**
    * Sets a new list for Fuse to match against.
-   * @param {Array} list
-   * @return {Array} The newly set list
+   * @param {!Array} list
+   * @return {!Array} The newly set list
    * @public
    */
   Fuse.prototype.set = function (list) {
@@ -512,6 +520,8 @@
    *
    * Licensed under the Apache License, Version 2.0 (the "License")
    * you may not use this file except in compliance with the License.
+   *
+   * @constructor
    */
   function BitapSearcher (pattern, options) {
     options = options || {}
@@ -589,10 +599,10 @@
 
   /**
    * Compute and return the result of the search
-   * @param {String} text The text to search in
-   * @return {Object} Literal containing:
-   *                          {Boolean} isMatch Whether the text is a match or not
-   *                          {Decimal} score Overall score for the match
+   * @param {string} text The text to search in
+   * @return {{isMatch: boolean, score: number}} Literal containing:
+   *                          isMatch - Whether the text is a match or not
+   *                          score - Overall score for the match
    * @public
    */
   BitapSearcher.prototype.search = function (text) {


### PR DESCRIPTION
I'm using Fuse in a project with [Closure-Compiler](https://github.com/google/closure-compiler) using `ADVANCED` optimizations. The fuse code was extremely close to being fully compatible. Just a couple type annotations are needed.

The only actual code changes required was initializing the initial options object was using reflection. I changed that in a way that is compatible with the compiler.