### PR TITLE
Add Typescript definitions.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for Fuse.js 2.5.0
+
+declare module 'fuse.js' {
+  export class Fuse {
+    constructor(list: any[], options?: IFuseOptions)
+
+    public search(pattern: string): any[];
+  }
+
+  interface IFuseOptions extends ISearchOptions {
+    caseSensitive?: boolean;
+    include?: string[];
+    shouldSort?: boolean;
+    searchFn?: any;
+    sortFn?: (a: { score: number }, b: { score: number }) => number;
+    getFn?: (obj: any, path: string) => any;
+    keys?: string[] | { name: string; weight: number }[];
+    verbose?: boolean;
+  }
+
+  interface ISearchOptions {
+    tokenize?: boolean;
+    tokenSeparator?: RegExp;
+    matchAllTokens?: boolean;
+    location?: number;
+    distance?: number;
+    threshold?: number;
+    maxPatternLength?: number;
+  }
+}
+
+declare const Fuse;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Lightweight fuzzy-search",
   "license": "Apache",
   "main": "./src/fuse.js",
+  "types": "./index.d.ts",
   "repository": "https://github.com/krisk/Fuse.git",
   "dependencies": {},
   "scripts": {


### PR DESCRIPTION
I added Typescript definitions because the API is simple enough that typings are easy to maintain. Modified package.json so Typescript will know where to find the type definition. Not sure if the definitions should be in ./src/fuse.d.ts or in ./index.d.ts, but I went with the latter (looking at other repos it seems like there isn't yet a convention for this). Feel free to change.