### PR TITLE
Fix typescript issues with commonjs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,32 +1,35 @@
 // Type definitions for Fuse.js 2.6.1
 
 declare module 'fuse.js' {
-  class Fuse {
-    constructor(list: any[], options?: FuseOptions)
-    search<T>(pattern: string): T[];
-    search(pattern: string): any[];
-  }
-
-  interface FuseOptions {
-    id?: string;
-    caseSensitive?: boolean;
-    include?: string[];
-    shouldSort?: boolean;
-    searchFn?: any;
-    sortFn?: (a: { score: number }, b: { score: number }) => number;
-    getFn?: (obj: any, path: string) => any;
-    keys?: string[] | { name: string; weight: number }[];
-    verbose?: boolean;
-    tokenize?: boolean;
-    tokenSeparator?: RegExp;
-    matchAllTokens?: boolean;
-    location?: number;
-    distance?: number;
-    threshold?: number;
-    maxPatternLength?: number;
-    minMatchCharLength?: number;
-    findAllMatches?: boolean;
-  }
+    namespace fuse.js {
+        export class Fuse {
+            constructor(list: any[], options?: fuse.js.FuseOptions)
+            search<T>(pattern: string): T[];
+            search(pattern: string): any[];
+        }
+        export interface FuseOptions {
+            id?: string;
+            caseSensitive?: boolean;
+            include?: string[];
+            shouldSort?: boolean;
+            searchFn?: any;
+            sortFn?: (a: { score: number }, b: { score: number }) => number;
+            getFn?: (obj: any, path: string) => any;
+            keys?: string[] | { name: string; weight: number }[];
+            verbose?: boolean;
+            tokenize?: boolean;
+            tokenSeparator?: RegExp;
+            matchAllTokens?: boolean;
+            location?: number;
+            distance?: number;
+            threshold?: number;
+            maxPatternLength?: number;
+            minMatchCharLength?: number;
+            findAllMatches?: boolean;
+        }
+    }
+    declare const Fuse = fuse.js.Fuse;
+    export = Fuse;
 }
 
-declare const Fuse;
+declare const Fuse: fuse.js.Fuse;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 declare module 'fuse.js' {
     namespace fuse.js {
         export class Fuse {
-            constructor(list: any[], options?: fuse.js.FuseOptions)
+            constructor(list: any[], options?: FuseOptions)
             search<T>(pattern: string): T[];
             search(pattern: string): any[];
         }


### PR DESCRIPTION
Thanks for creating a typescript definition!
I have issues using it though...
I expect to use it like this:
```ts
import * as Fuse from 'fuse.js'; // - won't work since the actual "class" is inside fuse - Fuse.Fuse
// or import {Fuse} from 'fuse.js'; // - won't work since there is no actual variable named Fuse inside Fuse
// or import 'fuse.js'; - I can't see the global deceleration if I import it that way since UMD doesn't declare global when commonjs is available
const seachResults = new Fuse(rows ...
```
all of the above don't work, as a workaround I can do this:
```ts
import * as F from 'fuse.js';
interface Type<T> extends Function {
    new (...args: any[]): T;
}
const Fuse: Type<F.Fuse> = <any>F;
```
but this is not ideal
That's why I've changed the typescript definitions to something I can use out-of-the-box with commonjs.