### PR TITLE
Fix typings based on TypeScript guidelines

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,16 @@
 // Type definitions for Fuse.js 2.6.1
 
-declare module 'fuse.js' {
-  class Fuse {
-    constructor(list: any[], options?: FuseOptions)
-    search<T>(pattern: string): T[];
-    search(pattern: string): any[];
-  }
+export = Fuse;
+export as namespace Fuse;
 
-  interface FuseOptions {
+declare class Fuse {
+  constructor(list: any[], options?: Fuse.FuseOptions)
+  search<T>(pattern: string): T[];
+  search(pattern: string): any[];
+}
+
+declare namespace Fuse {
+  export interface FuseOptions {
     id?: string;
     caseSensitive?: boolean;
     include?: string[];
@@ -28,5 +31,3 @@ declare module 'fuse.js' {
     findAllMatches?: boolean;
   }
 }
-
-declare const Fuse;


### PR DESCRIPTION
**_This is the GitHubified text of my Stack Overflow answer, verbatim_**

OK, here is what is happening and why. 
Firstly, Fuze/index.d.ts attempts to declare itself as both a global and as an ambient external module but does both of these incorrectly. This makes misuse, such as that which led your error almost inevitable. 
It contains a module declaration that contains a class declaration, presumably with the intent of describing the shape of the module but the class is not exported.
```ts
declare module 'fuse.js' {
  class Fuze // missing one of: export, export =, export default
}
```
This means that I cannot import the module correctly and in fact there is a type error when trying to import a value and/or type from it.
Further down in Fuse/index.d.ts it declares its global
declare const Fuse;
Presumably, based on conventions and reading the comments in the actual JavaScript, this is meant to have the same shape as what is exported from the module. Unfortunately, it has type any which is neither the same type as the attempted module, because it isn't valid, nor the the type of the class Fuse which is trapped inside said module but not exported...
So why the error? You probably have one of the following somewhere in your program: import 'fuse'; import Fuse from 'fuse'; import * as Fuse from 'fuse';
followed by some use of Fuse like
const myFuse = new Fuse();
This will cause an import for the runtime representation of Fuse fuse to be emitted by TypeScript, so that you can use the value imported from the module.
To fix the problem, you can use the global const Fuse and not import it anywhere. Unfortunately that is not what is intended. The author almost certainly meant to have the following content in Fuze/index.d.ts:
```ts
export = Fuse;

export as namespace Fuse;

declare class Fuse {
    constructor(list: any[], options?: Fuse.FuseOptions)
    search<T>(pattern: string): T[];
    search(pattern: string): any[];
}

declare namespace Fuse {
    export interface FuseOptions {
        id?: string;
        caseSensitive?: boolean;
        include?: string[];
        shouldSort?: boolean;
        searchFn?: any;
        sortFn?: (a: { score: number }, b: { score: number }) => number;
        getFn?: (obj: any, path: string) => any;
        keys?: string[] | { name: string; weight: number }[];
        verbose?: boolean;
        tokenize?: boolean;
        tokenSeparator?: RegExp;
        matchAllTokens?: boolean;
        location?: number;
        distance?: number;
        threshold?: number;
        maxPatternLength?: number;
        minMatchCharLength?: number;
        findAllMatches?: boolean;
    }
}
```
Which declares a class which is either available globally, for those not using ES Modules, or via an import for those who are. You can use the above UMD style declaration to gain the typing experience the author intended. The one bundled with the library provides no type information and actually results in errors when used.
Consider sending a pull request to the maintainer with the fix.
Usage:
You can use this declaration in the following ways:
**CommonJS TypeScript style**
```ts
import * as Fuse from 'fuse.js';

const myFuseOptions: Fuse.FuseOptions = {
  caseSensitive: false 
};
const myFuse = new Fuse([], myFuseOptions);
```
**Legacy CommonJS style**
```ts
import Fuse = require('fuse.js');

const myFuseOptions: Fuse.FuseOptions = {
  caseSensitive: false
};
const myFuse = new Fuse([], myFuseOptions);
```
**ES with CommonJS interop style**

(when using "module": "system" or "allowSyntheticDefaltImportsTrue") with SystemJS or if piping through Babel.
```ts
import Fuse from 'fuse.js';

const myFuseOptions: Fuse.FuseOptions = {
    caseSensitive: false
};
const myFuse = new Fuse([], myFuseOptions);
```