### PR TITLE
Added matchIndices location for array key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -283,8 +283,11 @@ class Fuse {
       }
     } else if (isArray(value)) {
       for (let i = 0, len = value.length; i < len; i += 1) {
+        // If value length > 1 then the key is for searching an array
+        let thiskey = (value.length > 1) ? key + '[' + i.toString() + ']' : key // maintaining array, object convention
+        
         this._analyze({
-          key, 
+          key: thiskey, 
           value: value[i], 
           record, 
           index
@@ -310,7 +313,9 @@ class Fuse {
 
       for (let j = 0; j < scoreLen; j += 1) {
         let score = output[j].score
-        let weight = weights ? weights[output[j].key].weight : 1
+        let arrayregex = /(\[\d*\])$/g // maintaining array, object convention
+        let key = !(arrayregex.test(output[j].key)) ? output[j].key : output[j].key.replace(arrayregex, '')
+        let weight = weights ? weights[key].weight : 1
         let nScore = score * weight
 
         if (weight !== 1) {


### PR DESCRIPTION
The current implementation does not give the location of the match for an array. That, in the example: http://fusejs.io/#searching-in-arrays-of-strings If I were to have not a single valued array like,

``` js
var books = [{
  'title': "Old Man's War",
  'author': 'John Scalzi',
  'tags': ['fiction','comedy']
}, {
  'title': 'The Lock Artist',
  'author': 'Steve',
  'tags': ['thriller','action']
}]

var options = {
  includeMatches: true,
  keys: ['author', 'tags'] 
};
var fuse = new Fuse(books, options)

fuse.search('tion')
```

**Output:**

```js
[{
  "item": {
    "title": "The Lock Artist",
    "author": "Steve",
    "tags": ["thriller", "action"]
  },
  "matches": [{
    "indices": [
      [2, 5]
    ],
    "key": "tags[1]" // [1] give the location of match in array
  }]
}, {
  "item": {
    "title": "Old Man's War",
    "author": "John Scalzi",
    "tags": ["fiction", "comedy"]
  },
  "matches": [{
    "indices": [
      [1, 1],
      [3, 6]
    ],
    "key": "tags[0]" //[0] give the location of match in array
  }]
}]
```

**PS:** I havn't built the src using `npm run build` to prevent unnecessary merge conflicts in `dist/*` on your master. I've run `npm test` and it honors all the code. I could update the `gh-pages` as soon as this request is accepted.