### PR TITLE
Fix undefined variable bug in "strict mode" function

### DIFF
--- a/dist/fuse.js
+++ b/dist/fuse.js
@@ -322,8 +322,8 @@ module.exports = function (text, pattern) {
   var matchedIndices = [];
 
   if (isMatch) {
-    for (i = 0, matchesLen = matches.length; i < matchesLen; i += 1) {
-      match = matches[i];
+    for (var i = 0, matchesLen = matches.length; i < matchesLen; i += 1) {
+      var match = matches[i];
       matchedIndices.push([text.indexOf(match), match.length - 1]);
     }
   }


### PR DESCRIPTION
Saw an "i is undefined" error thrown when searching patterns longer than the maxPatternLength.  Found two undefined variables in "strict mode" function.

I'm a GitHub newbie - this is my first pull request - so if I'm doing something wrong, let me know.