### PR TITLE
Fix #171: Do not include .babelrc in npm published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+.babelrc
+test/


### PR DESCRIPTION
This is the minimum required fix for #171. If you think it's a good idea, I can also add `test/` to `.npmignore`.

If you don't care about including `src/` in the published package, it's probably better to just whitelist `dist` in `package.json` : `"files": ["dist"]`
