### PR TITLE
deep_value cast numeric types to their string representations

### DIFF
--- a/src/helpers/deep_value.js
+++ b/src/helpers/deep_value.js
@@ -18,7 +18,7 @@ const deepValue = (obj, path, list) => {
     
     if (value !== null && value !== undefined) {
       if (!remaining && (typeof value === 'string' || typeof value === 'number')) {
-        list.push(value)
+        list.push(value.toString())
       } else if (isArray(value)) {
         // Search each item in the array.
         for (let i = 0, len = value.length; i < len; i += 1) {


### PR DESCRIPTION
since the analyze method works only on strings, in order to search numeric fields in deeply nested objects/arrays then numeric values need to be converted to their string representations:

use case:

const results = [
 {
    description:'Fuse.js is cool',
    meta:[
        {name:'javascript', value:'ecma7'}
        {name:'version', value:28954}
    ]
 }
]

const filterOptions = {
    shouldSort:true,
    threshold: 0.2,
    tokenize: true,
    location: 0,
    distance: 100,
    maxPatternLength: 32,
    minMatchCharLength: 1,
    keys: [
        'description', 
        'meta.name',
        'meta.value',
    ]
};

without this alteration, searching 28954 would not match