### PR TITLE
Convert numbers to string before search

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,7 +190,8 @@ class Fuse {
     let exists = false
     let averageScore = -1
     let numTextMatches = 0
-
+    
+    if (typeof value === 'number') value = String(value)
     if (typeof value === 'string') {
       this._log(`\nKey: ${key === '' ? '-' : key}`)
 


### PR DESCRIPTION
Hi,

I'm using Fuse recently for a project and is really powerful and lightweight, but for what I saw Fuse only search in strings and for this project I need to search also in numbers.

I just add a single line to cast numbers to string before search and get properly results.

Let me know is this is and accepted feature or if I need to continue using a fork.

Thanks