### PR TITLE
Fixed pattern matching false positive if the pattern length is greater than 32. (#136)

### DIFF
--- a/src/bitap/bitap_search.js
+++ b/src/bitap/bitap_search.js
@@ -48,7 +48,7 @@ module.exports = (text, pattern, patternAlphabet, { location = 0, distance = 100
   let finalScore = 1
   let binMax = patternLen + textLen
 
-  const mask = 1 << (patternLen - 1)
+  const mask = Math.pow(2, patternLen - 1)
 
   for (let i = 0; i < patternLen; i += 1) {
     // Scan for the best match; each iteration allows for one more error.

--- a/test/index.js
+++ b/test/index.js
@@ -1129,3 +1129,54 @@ vows.describe('Weighted search with exact match in arrays').addBatch({
     }
   }
 }).export(module);
+
+vows.describe('Search patterns that exceed 32 characters').addBatch({
+  'Patterns:': {
+    topic: function () {
+      var patterns = ['wwwww', 'wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww']
+      return patterns
+    },
+
+    'When matching a pattern less than 32 characters': {
+      topic: function (patterns) {
+        var options = {
+          maxPatternLength: 50,
+          minMatchCharLength: 4,
+          keys: [
+            'text'
+          ]
+        }
+        var list = [{
+          text: 'listItem'
+        }]
+        var fuse = new Fuse(list, options)
+        var matched = fuse.search(patterns[0]).length > 0
+        return matched
+      },
+      'We get the value false': function (matched) {
+        assert.deepEqual(matched, false)
+      }
+    },
+
+    'When matching a pattern greater than 32 characters': {
+      topic: function (patterns) {
+        var options = {
+          maxPatternLength: 50,
+          minMatchCharLength: 4,
+          keys: [
+            'text'
+          ]
+        }
+        var list = [{
+          text: 'listItem'
+        }]
+        var fuse = new Fuse(list, options)
+        var matched = fuse.search(patterns[1]).length > 0
+        return matched
+      },
+      'We get the value false': function (matched) {
+        assert.deepEqual(matched, false)
+      }
+    }
+  }
+}).export(module)


### PR DESCRIPTION
As stated in a previous comment, JS bitwise operations convert to Int32. So instead of using a left shift, I used Math.pow() for the mask.