### PR TITLE
Add auto-updating CDN link

### DIFF
--- a/index.html
+++ b/index.html
@@ -510,7 +510,16 @@
       CDN
     </h4>
 
-    Available on <a href="https://cdnjs.cloudflare.com/ajax/libs/fuse.js/3.0.4/fuse.min.js" target="_blank">cdnjs</a> (takes some time to sync so the latest version might not be available yet).
+    <p>Available on <a id="cdn-link" href="https://cdnjs.cloudflare.com/ajax/libs/fuse.js/3.2.1/fuse.min.js" target="_blank">cdnjs</a> (see the latest <a href="https://github.com/krisk/Fuse/releases" target="_blank">version on Github</a>).</p>
+
+    <script>
+      // Auto-update CDN link
+      $.getJSON( 'https://api.github.com/repos/krisk/Fuse/tags' ).done( ( json ) => {
+        var ver = json[0].name.substring( 1 )
+        var CDNURL = 'https://cdnjs.cloudflare.com/ajax/libs/fuse.js/' + ver + '/fuse.min.js'
+        $( '#cdn-link' ).attr( 'href', CDNURL )
+      } )
+    </script>
 
     <br>
     <br>

--- a/index.html
+++ b/index.html
@@ -514,10 +514,8 @@
 
     <script>
       // Auto-update CDN link
-      $.getJSON( 'https://api.github.com/repos/krisk/Fuse/tags' ).done( ( json ) => {
-        var ver = json[0].name.substring( 1 )
-        var CDNURL = 'https://cdnjs.cloudflare.com/ajax/libs/fuse.js/' + ver + '/fuse.min.js'
-        $( '#cdn-link' ).attr( 'href', CDNURL )
+      $.getJSON( 'https://api.cdnjs.com/libraries?search=fuse' ).done( function( json ) {
+        $( '#cdn-link' ).attr( 'href', json.results[0].latest )
       } )
     </script>
 


### PR DESCRIPTION
I added a simple function to update the cdnjs link. Let me know what you think

Also, StumbleUpon shutdown last month and the widget link is broken: https://techcrunch.com/2018/05/24/so-long-stumbleupon/. Stumbleupon is now moved to Mix in case you wanted to update the social link