### PR TITLE
Add setCollection method to Fuse type definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,8 @@ export as namespace Fuse;
 declare class Fuse<T> {
   constructor(list: ReadonlyArray<T>, options?: Fuse.FuseOptions)
   search(pattern: string): T[];
+
+  setCollection(list: ReadonlyArray<T>): ReadonlyArray<T>;
 }
 
 declare namespace Fuse {


### PR DESCRIPTION
This allows to swap lists at runtime.

```ts
const fuse = new Fuse<Book>(oldBooks, options);
fuse.setCollection(newBooks);
const results: Book[] = fuse.search("old");
```

Thanks!