### PR TITLE
Add TypeScript definition for `matches` property on a result.

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -20,7 +20,12 @@ declare class Fuse<T, O extends Fuse.FuseOptions<any> = Fuse.FuseOptions<any>> {
 declare namespace Fuse {
   export interface FuseResult<T> {
     item: T,
-    matches?: any;
+    matches?: {
+      indices: [number, number][];
+      value: string;
+      key: string;
+      arrayIndex: number;
+    }[];
     score?: number;
   }
   export interface FuseOptions<T> {


### PR DESCRIPTION
The `matches` property is currently defined as `any`; but since it has a consistent shape, we can strongly-type it instead.