### PR TITLE
Add type definitions for matches

### DIFF
--- a/dist/fuse.d.ts
+++ b/dist/fuse.d.ts
@@ -20,8 +20,15 @@ declare class Fuse<T, O extends Fuse.FuseOptions<any> = Fuse.FuseOptions<any>> {
 declare namespace Fuse {
   export interface FuseResult<T> {
     item: T,
-    matches?: any;
+    matches?: FuseMatch[];
     score?: number;
+  }
+
+  export interface FuseMatch {
+    indices: [number, number][]
+    value: string
+    key?: string
+    arrayIndex?: number
   }
   export interface FuseOptions<T> {
     id?: keyof T;

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -20,8 +20,15 @@ declare class Fuse<T, O extends Fuse.FuseOptions<any> = Fuse.FuseOptions<any>> {
 declare namespace Fuse {
   export interface FuseResult<T> {
     item: T,
-    matches?: any;
+    matches?: FuseMatch[];
     score?: number;
+  }
+
+  export interface FuseMatch {
+    indices: [number, number][]
+    value: string
+    key?: string
+    arrayIndex?: number
   }
   export interface FuseOptions<T> {
     id?: keyof T;


### PR DESCRIPTION
Previously matches had `any` type which wasn't helpful.

Example match when input is array of strings
```
      {
        "indices": [
          [
            1,
            1
          ],
          [
            3,
            3
          ],
          [
            6,
            12
          ]
        ],
        "value": "anotherString"
      }
```

Example match when input is objects:
```
      {
        "indices": [
          [
            1,
            1
          ],
          [
            3,
            3
          ],
          [
            6,
            12
          ]
        ],
        "value": "anotherString",
        "key": "name",
        "arrayIndex": 0
      }
```

Ideally the matches should be consistent, but until: https://github.com/krisk/Fuse/issues/287 this should at least type the `value` and `indices` as most people will only want the indices.
