### PR TITLE
Fix typings for (deep) nested keys

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -30,7 +30,7 @@ declare namespace Fuse {
     shouldSort?: boolean;
     sortFn?: (a: { score: number }, b: { score: number }) => number;
     getFn?: (obj: any, path: string) => any;
-    keys?: (keyof T)[] | { name: keyof T; weight: number }[];
+    keys?: (keyof T)[] | T[keyof T] | { name: keyof T; weight: number }[];
     verbose?: boolean;
     tokenize?: boolean;
     tokenSeparator?: RegExp;


### PR DESCRIPTION
This fixes the typings for nested keys which was previously broken, and
reported by @mmajko on #261

While this does fix the typings at least for now, they can be made even
more ideal. To achieve this however advanced typings would be required
and a request has been made to the utility-types repository (see:
https://github.com/piotrwitek/utility-types/issues/85) for the required
advanced type. To summarize that issue, if we would have a Flatten<T>
that would flatten the entire given typing T to single keys it would be
a perfect match for this library.

Please note that this should be merged alongside #310 as it updates the docs to reflect the issue that this PR covers.

Before:

![image](https://user-images.githubusercontent.com/4019718/58348312-a1eaf180-7e60-11e9-98ff-15174dd3e550.png)

After:

![image](https://user-images.githubusercontent.com/4019718/58348275-854eb980-7e60-11e9-9a5a-990cf1622c0f.png)

And lastly an image with a very deep nested key which still works:
![image](https://user-images.githubusercontent.com/4019718/58348673-8f24ec80-7e61-11e9-9c7a-78db7ccfd37a.png)

