### PR TITLE
fixed test filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ Code should be run through [Standard Format](https://www.npmjs.com/package/stand
 
 ### Testing
 
-Before submitting a pull request, please add relevant tests in `test/index.js`, and execute them via `npm test`.
+Before submitting a pull request, please add relevant tests in `test/fuse.test.js`, and execute them via `npm test`.
 


### PR DESCRIPTION
On commit 48e55f7a7b96c90e3fc0386df21df5846e1983ef ported tests to the Jest framework, but forgot to update readme.