### PR TITLE
fix & enhance type definition of search() 

### DIFF
--- a/dist/fuse.d.ts
+++ b/dist/fuse.d.ts
@@ -10,18 +10,35 @@ interface SearchOpts {
 
 declare class Fuse<T, O extends Fuse.FuseOptions<T>> {
   constructor(list: ReadonlyArray<T>, options?: O)
-  search(pattern: string, opts?: SearchOpts): O extends { id: keyof T } ?
-    O extends ({ includeMatches: true; } | { includeScore: true; }) ? Fuse.FuseResult<string>[] : string[] :
-    O extends ({ includeMatches: true; } | { includeScore: true; }) ? Fuse.FuseResult<T>[] : T[];
+  search<
+    /** Type of item of return */
+    R = O extends { id: string } ? string : T,
+    /** include score (boolean) */
+    S = O['includeScore'],
+    /** include matches (boolean) */
+    M = O['includeMatches'],
+  >(pattern: string, opts?: SearchOpts):
+      S extends true ? (
+        M extends true ?
+          (Fuse.FuseResultWithMatches<R> & Fuse.FuseResultWithScore<R>)[] :
+          Fuse.FuseResultWithScore<R>[]
+      ) : (
+        M extends true ?
+          Fuse.FuseResultWithMatches<R>[] :
+          R[]
+      )
 
   setCollection(list: ReadonlyArray<T>): ReadonlyArray<T>;
 }
 
 declare namespace Fuse {
-  export interface FuseResult<T> {
+  export interface FuseResultWithScore<T> {
     item: T,
-    matches?: any;
-    score?: number;
+    score: number;
+  }
+  export interface FuseResultWithMatches<T> {
+    item: T,
+    matches: any;
   }
   export interface FuseOptions<T> {
     id?: keyof T;

--- a/dist/fuse.d.ts
+++ b/dist/fuse.d.ts
@@ -41,14 +41,14 @@ declare namespace Fuse {
     matches: any;
   }
   export interface FuseOptions<T> {
-    id?: keyof T;
+    id?: keyof T | string;
     caseSensitive?: boolean;
     includeMatches?: boolean;
     includeScore?: boolean;
     shouldSort?: boolean;
     sortFn?: (a: { score: number }, b: { score: number }) => number;
     getFn?: (obj: any, path: string) => any;
-    keys?: (keyof T)[] | T[keyof T] | { name: keyof T; weight: number }[];
+    keys?: (keyof T | string)[] | { name: keyof T | string; weight: number }[];
     verbose?: boolean;
     tokenize?: boolean;
     tokenSeparator?: RegExp;

--- a/dist/fuse.d.ts
+++ b/dist/fuse.d.ts
@@ -8,7 +8,7 @@ interface SearchOpts {
   limit?: number
 }
 
-declare class Fuse<T, O extends Fuse.FuseOptions<any> = Fuse.FuseOptions<any>> {
+declare class Fuse<T, O extends Fuse.FuseOptions<T>> {
   constructor(list: ReadonlyArray<T>, options?: O)
   search(pattern: string, opts?: SearchOpts): O extends { id: keyof T } ?
     O extends ({ includeMatches: true; } | { includeScore: true; }) ? Fuse.FuseResult<string>[] : string[] :

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -7,7 +7,7 @@ interface SearchOpts {
   limit?: number
 }
 
-declare class Fuse<T, O extends Fuse.FuseOptions<any> = Fuse.FuseOptions<any>> {
+declare class Fuse<T, O extends Fuse.FuseOptions<T>> {
   constructor(list: ReadonlyArray<T>, options?: O)
   search(pattern: string, opts?: SearchOpts): O extends { id: keyof T } ?
     O extends ({ includeMatches: true; } | { includeScore: true; }) ? Fuse.FuseResult<string>[] : string[] :

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -40,14 +40,14 @@ declare namespace Fuse {
     matches: any;
   }
   export interface FuseOptions<T> {
-    id?: keyof T;
+    id?: keyof T | string;
     caseSensitive?: boolean;
     includeMatches?: boolean;
     includeScore?: boolean;
     shouldSort?: boolean;
     sortFn?: (a: { score: number }, b: { score: number }) => number;
     getFn?: (obj: any, path: string) => any;
-    keys?: (keyof T)[] | T[keyof T] | { name: keyof T; weight: number }[];
+    keys?: (keyof T | string)[] | { name: keyof T | string; weight: number }[];
     verbose?: boolean;
     tokenize?: boolean;
     tokenSeparator?: RegExp;

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -9,18 +9,35 @@ interface SearchOpts {
 
 declare class Fuse<T, O extends Fuse.FuseOptions<T>> {
   constructor(list: ReadonlyArray<T>, options?: O)
-  search(pattern: string, opts?: SearchOpts): O extends { id: keyof T } ?
-    O extends ({ includeMatches: true; } | { includeScore: true; }) ? Fuse.FuseResult<string>[] : string[] :
-    O extends ({ includeMatches: true; } | { includeScore: true; }) ? Fuse.FuseResult<T>[] : T[];
+  search<
+    /** Type of item of return */
+    R = O extends { id: string } ? string : T,
+    /** include score (boolean) */
+    S = O['includeScore'],
+    /** include matches (boolean) */
+    M = O['includeMatches'],
+  >(pattern: string, opts?: SearchOpts):
+      S extends true ? (
+        M extends true ?
+          (Fuse.FuseResultWithMatches<R> & Fuse.FuseResultWithScore<R>)[] :
+          Fuse.FuseResultWithScore<R>[]
+      ) : (
+        M extends true ?
+          Fuse.FuseResultWithMatches<R>[] :
+          R[]
+      )
 
   setCollection(list: ReadonlyArray<T>): ReadonlyArray<T>;
 }
 
 declare namespace Fuse {
-  export interface FuseResult<T> {
+  export interface FuseResultWithScore<T> {
     item: T,
-    matches?: any;
-    score?: number;
+    score: number;
+  }
+  export interface FuseResultWithMatches<T> {
+    item: T,
+    matches: any;
   }
   export interface FuseOptions<T> {
     id?: keyof T;


### PR DESCRIPTION
TypeScript Playground Links: [Current version](https://www.typescriptlang.org/play/#code/PTAEGMFcCdoUwHYBdQDc7QM4EsD2CBYAKG2QwDMBDcOUAEUqUtAG9jQPQlskAbOAFyhMSaKQDmAbnadKkJAAtc0IWyKcNoctixIAcpQC2g4aInT1mjr0oiDxoSLEIpMjgF8L74gBM44G3gIfBFQXmwRIQYmAG0AXQtiYAAqUAAjW2xwUGTgYgAKAEpQAF4APlYZcBCUckhMWhLQBDgAd1AAMXq4fPCRABpWUABrOABPTCEYgHJuPjhpuNB3QosOaoRQ+En6Rkp40q1ugDoGymhwBXzp0bHW5R9p1ZkQUFxh4+JvIiTU3AAHbj4UCtHgKUDYHw5PJEIqlCpqdY1I4NQ4tdpdBq9CJIQYsEbjHYzOb8RaDSFCWY8UnLZ6WV51BqnODnS7CJSQXhQ+BIGAIUzOcTxQZVZHbRxmFwHJqMuDM1lXG7je7QR5014YFSgAB6oAAKmN-rRptFKNMIZhmrgULYcOIEJQ0vwuLguIbjU4JNNPkRvr9hNUgkh3dCCsVypVLBtQrK0W1Ot1sQMhrciVT5mSIQgApA-ABlQMmUSQWgrNbBTYobaHWXyi6K24qtXl6O4fjHXi4cT5bYxAAMcVOhdAAB4mn3jgBWOkcDWwIQaXUAeTSACt-CgIqB-rhMDgnWNQNNIAg-NoWo8fX6iCkrQgALThJAYSi8N6AvD83Brjeh2HhhFRUrd8gQQIRMTlCClw-EIR1NComnxCkjxJBZBlTKZ01JOJyWzXhczgAtlCLaAS2WFtkVjJp0QTLE+lxEDPxnUAGROM563ZXBOW5OBeWgfkkOfQwJUFQZMELIQEEgQw0gwZYgK2OBLRlNiWXra5GweJ4KOA5DPRcQ5ewHY4eDgQxyznaBlAXKxbI4XUAAUrKNaBgyPUzDHNHxcCUq0UDgAAPHE3n5YMjSPU1vQUlBxOIyTpNk6BDKU-tB1i+ALLATVrLs3LOEc5yMDc6Z0oWUBvN8hBrVAQLguBMLjUiq9iH9FoRDgKFUz-OEI0RCtQgBUCdgg44oJgzY4L2BDIw0ZDpjkRRlA7Wx9CMNCkjAHV9RDaYACIFqUaBlrsNbdvNLcqptPdsHtR1nSQV0GqPXbUN20AAB9QH2+RDrOn0NAw0AZgOpabBO4xFg2+ztvCvaQaOsHVuMM6LT80BbRuh0nVoB63Vhl7qTgN7Pu+xboD+mRvmvFqb1SEp6YZxmUTlHxjiQZTGc5ppchp0hn2gKgaFAPM1MuaD2ZmsJsEMHgAH54pkjAvhpvwAnOWg1b3Wi4BHPVBiXGqAufU9LRGsahpHSgEDGaaze6cXP0wS3rbKQCoxqUjwAe6AkyQIQACUWW8hBeDGABBWBKDGXWykGQbHfl0Al0KGR2MufJ-kYfmwIFCQ48BTBE5FhVxcwQohANwLjZ8S0kJ8IRblwch9WWUBZbcJPDery18iQvCCIAWUYS4lKEYs4EkVvPr7nN8wkrhSIn2k2+10bukDzBOSQEd9PEMoDhEiQD47yujcQGvQF7rNZ7gIekBHnZx8n9wPqGUgb6I+Ax8X5-ill1eIIby3jHA++p4iJEsA0JAABhNs-Avafl9gHIO+BQ4R2gFHGO5dQCB0oMHNBkdo56jKF4FW-hAi0AdMYTAmchYQUloFHcrksz80FrQQBSlgHEMlhwDyQg9Yd0MMPBQSlE5WzGOWDgpVE5SUVtAcs3wOCMOUJuMgAtqDsPtuNJ23C+q8J8InRuzc9SSIgLYQiiAcDcHQInNIuA2wsgQKY9++E-B3wfrY+x-ArbOP7nPYiniHE+I7pgDkXI8wqMCd4pxISVEdAQInfIlBVABjis0BKcl3CDDSCk0qCtErLwjLIxKpjxC8XiYk78q4hDiMGJnRQh8XAAXRtbUxqZElGP1IUA4n09QxE6XqJY09mhrQbuMJu+pJ6tDgDdBQft0lyOWOAju6BoB2IaFExxpiHqjAQNgAAXnATZwTLAcB2YgEWmcMHe0ToHcQABRAK-xTFCPvgoMOvBeB6neJY45MTTlhFwOARgn4ZEZPkR3HwOIrY0DBXI7ZChthKC5HCkpgjKABQclnDACAAAyiBxCKFRRgF5pB3EKGgQoc4+KXBEvySSju54fAfN4OS0RQg7FBP+R4L4QA) / [PR version](https://www.typescriptlang.org/play/#code/PTAEAUCVQNwUwE4GcCWB7AdgWAFAowC6IBmAhgMZygAipBpoA3rqK6ASgQDZwBcoSAgnwBzANws2pAK4EAFmgT9mONmtDEUyAgDlSAWz4ChoiavWsupQXsP9BwjOMmsAvmde4AJnHJWEVOSYgqBcKIL8tPQA2gC6ZrjAAFSgAEbWKOSgScC4ABQAlKAAvAB8TJJBGCHE0khUxaAYcADuoABidXB5YYIANEygANZwAJ5I-NEA5BzccFOxoK4FZqxVIQETNHSkcSUaXQB09aQI5HJ5UyOjLYpeUyuSIKBoQ4e4njiJKWgADhyYUAtThyUAoLzZXI4QolcoqNbBAgHer7ZptTr1HrhAgDRjDMZbaazHgLAbg-gzTgkpaPczrJGbewmJx7Rq1erHOCnc6Xa63BD3FagZ6vd44T7fARBALsUa-Kg5fJFMoVOmI5ENJqtDpdLH9QbXQmUuaksEYPzSHwAZWlRiE0ioy1WoHpoE2+3ZcE53IuVzG-MFzvWaB4hy4aBEeU20QADLFjrbQAAeRoxw4AViFrBFbw+uElGEwAFowkQEKQuC9-ugMJClbDVQjqki-gCMLwMV7OwB5avBJNRUjlRp48mgY0kgaGyYT+axMnmriWuA2xR2hAOpZB9We1Hazt6nFVtu07NgT3es6gpAKaRcCEBAjSBC10dEfRMxwiAZIW38DDSPoqSIEslTqpsMYekcJxXry-p3A8sbxGBzZgl4n6iPsEGHJwcD6M6zyCCgXCVuQMgoogCCKPwrAAHoQFR8oIAQozjrh+hTKAXhoHASBNGgSJwAAHtiLy1ix8rjoOUxik2IS-mu-6AcBCBYbxaYKQEBFgERJEuuRVCUdRFj0eAjGICx46afMXE8XxhaCSJISAhJVBTNJYqfMkLzwAgwg+LKkn4MQiBwOaCpQjCKrwi66qtjWHZHD2fbVAOOzDoMY6zlMU4EjOxJzguFrWn+7Abo626obujRojqmK9Ee8WYKesWoRBUEcjB5xJg4ogDPacADGQXD1KUcE3AhBRIZVIRjr1ThqUgabsWIwpgKKKHyaVAFASBjTYdZq05p5+ZfDg3nNIIcAQoadbQsqcKbS2KVbJ2hzJW2SBpfQGUxawWUyPIihhtYugGPMfQuPi4wzoDCgICDNjgwsUPHZInwSmdkrFDjuN4xqhxeIcBB8XjZM43diRgAAKnKVA+JoGCcDWfHEIodVegAVnxMAAMyHAALBmVOgLT8o2sI-ygAAaogqCYPw-MAIynfgZZkJQoBWlyV69iTjahCg+icAA-Epu0IHmZ0+H4pyBFYSB8Z2SbUwM3agMJRAYF4TtJV0essy7pSPWqzYbuQBCKIe-CQFy3EYFwowAIJ+aQoxBwMTXVGboDdgUkhdXISao0kKRi1QaDEGC74vFXj7PrWirmKw0CNO7nthT7mXocYX5LKAJu95h-CuyXKT4MVVDWaAeSpGgIZchgRRN2oVr7N20wT0uJVrqSY9mpPoD6HQ5y8TPc8L6QS93WoACy6+b4uy63yfci8Xv5hjb8dBlu2Q9OJnf4SAc7ax9HrJABReBQ1YGvDu3s+IDQHjPaBbB75wK7ogk2KC1B5Dep2WOSA7wEAAOoghfgQU+X1IDlAAGQc3el0AhRDSHyFXAEJM1CpqLCgc3Cw9D8G8WYSCNhcAOGlDiCgoo-A8jYNAGgoSXsMHlQHrI1geDGGCK4CQshr9eJiL2DwvhbBIASN4awfOZ1WD1AIAAYRDDwCONZo6gFjqQeOicU7lnTtTUokCXFx0wB41O3jSgeFOjbfwVAMDgyQN-TWnYDbCV+IoJEasSAUCoAIwhWiWFyBEUHA2-13wj0hrw6y5sVLOk+KwJJKSzTqwyRzJhOSdEULfl9HxhTq54RKVDY+bTeL8CvqMKpkhanMXqek+J-sXoFL+mhHO1xK6i1AAAH3-s4XhZF6ja2qMzeAOcL48Cvs6f6T8fDkMoYc+exyMCnIPtvFctprmXzuVDG8aA7xeCtCkl5tz7lIBSe0DAOc8ikGUFKRSTRlIgVcAMVIELynQotjSBsO1KlQxEHAAgwLQVoFSJzIZGBRgDG-vIDCTgHqgGGfcw0oKllV2pmsjZXDmV4miXYaGyymXrPmuIIEcAUAiDkAQCpsK4j3N8nPeofzF73MjiMJmAAvOAsqTlQwVWFbW39yyRwQDnWOIgACiQlfj3P6ecJOJFqavDCsA-gRy5VQ3DGRNsOd0WIHuV4bEV9KDuphQgeVchNgKHvP6i25rSBCXAD-RAGAAAyYURDyHDRi3hxsMCXLkDYuQpxE1OBTWKwNUNGZeCtVwLNvE1VvPMBjU6QA)

---

`fuse.search` should return `string[]` with option includes `id`

**Current:**
```ts
const fuse = new Fuse(list, { keys: ['title'], id: 'title' });
const res: string = fuse.search('keyword');
//err ^ Type 'Data' is not assignable to type 'string'.
```

**PR:**
```ts
const fuse = new Fuse(list, { keys: ['title'], id: 'title' });
const res: string[] = fuse.search('keyword'); // ok.
```

---

`score: number | undefined` is troublesome to handle with `--strictNullChecks`

**Current:**
```ts
const fuse = new Fuse(list, { keys: ['title'], includeScore: true });
const res = fuse.search('keyword');
console.log(res[0].score <= 0.5);
// err:     ^ Object is possibly 'undefined'.
```

**PR:**
```ts
const fuse = new Fuse(list, { keys: ['title'], includeScore: true });
const res = fuse.search('keyword');
console.log(res[0].score <= 0.5);  // ok.
```

---

with no-literal option object, TS cannot infer type of return of `search()` (#303)

**Current:**
```ts
const option: Fuse.FuseOptions<Data> = { id: 'title', keys: ['title'], includeScore: true };
const fuse = new Fuse(list, option);
const res0 = fuse.search('keyword')[0];
const id: string = res0.item;
// error:               ^ Property 'item' does not exist on type 'Data'.
const score: number = res0.score;
// error:                  ^ Property 'score' does not exist on type 'Data'.
```

this is not fixed, but now type inference can be overridden

**PR:**
```ts
const option:Fuse.FuseOptions<Data> = { id: 'title', keys: ['title'], includeScore: true };
const fuse = new Fuse(list, option);
const res0 = fuse.search<string, true, false>('keyword')[0];
const id: string = res0.item; // ok.
const score: number = res0.score; // ok.
```

---

248ee3176a9bf181d8425570981da82cedc4d695 is not working

**Current:**
```ts
const options: Fuse.FuseOptions<Data> = {
  id: 'author.lastName',
//^ Type '"author.lastName"' is not assignable to type '"title" | "author"'.
  keys: ['author.lastName']
//^ Type '"author.lastName"' is not assignable to type '"title" | "author"'.
}
```

**PR:**
```ts
const options: Fuse.FuseOptions<Data> = {
  id: 'author.lastName',  // ok.
  keys: ['author.lastName']  // ok.
}
```
