### PR TITLE
Add installation instructions to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ Fuse.js is a lightweight fuzzy-search, in JavaScript, with zero dependencies.
 
 To checkout out [live examples](https://fusejs.io) and docs, visit [fusejs.io](https://fusejs.io).
 
+## Installation
+
+__NPM__
+
+NPM is the recommended installation method. It pairs nicely with a CommonJS module bundler such as [Webpack](http://webpack.github.io/) or [Browserify](http://browserify.org/).
+
+```sh
+# latest stable
+$ npm install --save fuse.js
+```
+
+__CDN__
+
+Available on [cdnjs](https://cdnjs.cloudflare.com/ajax/libs/fuse.js/3.4.5/fuse.min.js) (see the latest version on [the Releases page](https://github.com/krisk/Fuse/releases)).
+
 ## Contributing
 
 ### Coding conventions


### PR DESCRIPTION
Most npm packages have installation instructions on their Github homepage, so I
did expect to find them here.

I copied these instructions from fusejs.io but chose to put NPM first; NPM is the recommended installation method and Github users are arguably more likely to use it than website-only users.