### PR TITLE
Added list property in typings

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -28,6 +28,7 @@ declare class Fuse<T, O extends Fuse.FuseOptions<T>> {
       )
 
   setCollection(list: ReadonlyArray<T>): ReadonlyArray<T>;
+  list: ReadonlyArray<T>
 }
 
 declare namespace Fuse {

--- a/test/fuse.test.js
+++ b/test/fuse.test.js
@@ -42,6 +42,10 @@ describe('Flat list of strings: ["Apple", "Orange", "Banana"]', () => {
     expect(fuse).toMatchObject(expected)
   })
 
+  it('should have the list property', () => {
+    expect(fuse.list).toBe(defaultList)
+  })
+
   describe('When searching for the term "Apple"', () => {
     let result
     beforeEach(() => result = fuse.search('Apple'))


### PR DESCRIPTION
Can we add the `list` property? I found it usefull when searching inactive and for Typescript it has thrown an error for now

Otherwise, I will need to pass two properties
1. Fuse instance
2. original list