### PR TITLE
Fix CDN link on fusejs.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -536,7 +536,7 @@
 
               <script>
                 // Auto-update CDN link
-                $.getJSON( 'https://api.cdnjs.com/libraries?search=fuse' ).done(function (json) {
+                $.getJSON( 'https://api.cdnjs.com/libraries?search=fuse.js' ).done(function (json) {
                   $('#cdn-link').attr( 'href', json.results[0].latest)
                 })
               </script>


### PR DESCRIPTION
A simple search for 'fuse' does not return the correct results. The currently returned best match is React.

This modifies the search query for fuse.js, which returns the correct results.