### PR TITLE
Target es5 in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "es6",
     "lib": ["es6"],
-    "target": "es6",
+    "target": "es5",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Fixes #374 

This makes `tsc` transpile code to ES5 (but with ES6 `import` / `export` module option) for the esm bundle be both tree-shakable and IE-11 compatible.