### PR TITLE
Update IFuseOptions to use isCaseSensitive

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -181,7 +181,7 @@ declare namespace Fuse {
   }
 
   export interface IFuseOptions<T> {
-    caseSensitive?: boolean
+    isCaseSensitive?: boolean
     distance?: number
     findAllMatches?: boolean
     getFn?: FuseGetFunction<T>


### PR DESCRIPTION
The docs use `isCaseSensitive`, but `index.d.ts` uses `caseSensitive`. https://fusejs.io/api/options.html#iscasesensitive