### PR TITLE
Add useExtendedSearch to example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -261,6 +261,7 @@ const books = [
 
 ```javascript
 const options = {
+  useExtendedSearch: true,
   includeScore: true,
   keys: ['author']
 }


### PR DESCRIPTION
This page here: https://fusejs.io/examples.html#extended-search

Is missing using the `useExtendedSearch ` option to make it work


Thank you for this new website