### PR TITLE
Remove duplicate key in example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -261,7 +261,6 @@ const books = [
 
 ```javascript
 const options = {
-  useExtendedSearch: true,
   includeScore: true,
   useExtendedSearch: true,
   keys: ['author']


### PR DESCRIPTION
Removes a duplicate key `useExtendedSearch` in the Extended Search example.