### PR TITLE
Added deno import 🦕

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ Available on CDN via [jsDelivr](https://cdn.jsdelivr.net/npm/fuse.js/dist/).
 
 > Note: it takes some time for the CDNs to sync with the latest version
 
+**Deno**
+
+Available in Deno via [deno.land/x](https://deno.land/x/fuse)
+
+```typescript
+// @deno-types="https://deno.land/x/fuse@v6.0.4/dist/fuse.d.ts"
+import Fuse from 'https://deno.land/x/fuse@v6.0.4/dist/fuse.esm.min.js';
+```
+
 ### Explanation of Different Builds
 
 In the [`dist/` directory of the NPM package](https://cdn.jsdelivr.net/npm/fuse.js/dist/) you will find many different builds of Fuse.js. Here's an [overview](https://fusejs.io/getting-started/different-builds.html) of the difference between them.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -50,6 +50,6 @@ version in your published site, replacing `fuse.js` with `fuse.min.js`. This is 
 You can directly import `Fuse` as an ES module from the deno.land/x service:
 
 ```typescript
-// @deno-types="https://deno.land/x/fuse/dist/fuse.d.ts"
-import Fuse from 'https://deno.land/x/fuse/dist/fuse.esm.min.js';
+// @deno-types="https://deno.land/x/fuse@v6.0.4/dist/fuse.d.ts"
+import Fuse from 'https://deno.land/x/fuse@v6.0.4/dist/fuse.esm.min.js';
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -44,3 +44,10 @@ Fuse.js is also available on [unpkg](https://unpkg.com/fuse.js).
 
 Make sure to read about the different builds of Fuse.js and use the production
 version in your published site, replacing `fuse.js` with `fuse.min.js`. This is a smaller build optimized for speed instead of development experience.
+
+### Deno
+
+```typescript
+// @deno-types="https://deno.land/x/fuse/dist/fuse.d.ts"
+import Fuse from 'https://deno.land/x/fuse/dist/fuse.esm.min.js';
+```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -47,6 +47,8 @@ version in your published site, replacing `fuse.js` with `fuse.min.js`. This is 
 
 ### Deno
 
+You can directly import `Fuse` as an ES module from the deno.land/x service:
+
 ```typescript
 // @deno-types="https://deno.land/x/fuse/dist/fuse.d.ts"
 import Fuse from 'https://deno.land/x/fuse/dist/fuse.esm.min.js';


### PR DESCRIPTION
Hello!

I was using Fuse for a side project that used the deno runtime. It worked perfectly, so I added it to the deno.land/x rewriting service: https://deno.land/x/fuse

The ESM version can be directly imported by its URL, along with the typescript defs. Here's a repl showing Fuse working with deno: https://repl.it/@lunaroyster/Fusejs-deno

`https://deno.land/x/fuse@v6.0.4/dist/fuse.esm.min.js` just points to `https://raw.githubusercontent.com/krisk/Fuse/v6.0.4/dist/fuse.esm.min.js` 

Thanks! :D