### PR TITLE
fix js tab to be compliant with output tab

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -316,7 +316,7 @@ const books = [
 const options = {
   includeScore: true,
   useExtendedSearch: true,
-  keys: ['author']
+  keys: ['title']
 }
 
 const fuse = new Fuse(books, options)


### PR DESCRIPTION
use 'artist' as search key option will produce no results, probably this is a typo because fuse.search("'Man 'Old | Artist$") will produce the expected result only if you search inside "title" key