### PR TITLE
docs(install): add usage with require and import

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,6 +14,20 @@ $ npm install --save fuse.js
 $ yarn add fuse.js
 ```
 
+### `require` and `import`
+
+If you're using `import`:
+
+```js
+import Fuse from "fuse.js";
+```
+
+If you're using `require`:
+
+```js
+const Fuse = require("fuse.js");
+```
+
 ### Direct `<script>` Include
 
 Simply download and include with a script tag. `Fuse` will be registered as a global variable.


### PR DESCRIPTION
Hi there!

While it may seem obvious that the way to import/require the library is the way I added documentation for, it was not for me! (and maybe others, see https://github.com/krisk/Fuse/issues/209)

Especially because the first page after "Installation" is "Different builds". Different builds to me meant that maybe I had to use import Fuse from "fuse.js/basic" or import Fuse from "fuse.js/full" etc..

Side note: I believe it would be good to be able to do:
```js
import Fuse from fuse.js/basic
```

```js
import Fuse from fuse.js/full
```

Thanks!