### PR TITLE
 chore: use "!" in license to avoid minification

### DIFF
--- a/scripts/configs.js
+++ b/scripts/configs.js
@@ -12,7 +12,7 @@ const AUTHOR = pckg.author
 const HOMEPAGE = pckg.homepage
 const DESCRIPTION = pckg.description
 
-const banner = `/**
+const banner = `/*!
  * Fuse.js v${VERSION} - ${DESCRIPTION} (${HOMEPAGE})
  *
  * Copyright (c) ${new Date().getFullYear()} ${AUTHOR.name} (${AUTHOR.url})


### PR DESCRIPTION
Using `/*!` for starting license blocks seems to be a typical approach to tell minifiers not to remove them.

For example, terser-webpack-plugin docs:
https://github.com/webpack-contrib/terser-webpack-plugin/#extractcomments