### PR TITLE
Fix out of bounds array access in remove method

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -54,6 +54,7 @@ export default class Fuse {
       if (predicate(doc, i)) {
         this.removeAt(i)
         i -= 1
+        len -= 1
 
         results.push(doc)
       }


### PR DESCRIPTION
First off, thanks for the library! It's really nice to work with. :)

I noticed that the remove method passes undefined to the predicate. So yeah, out of bounds access.

I'm in a bit of a rush so I don't have the time to write a test, apologies. 🙏 