### PR TITLE
Fix typo on the Methods Documentation page

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -2,7 +2,7 @@
 
 ### `search`
 
-Sarches the entire collection of documents, and returns a list of search results.
+Searches the entire collection of documents, and returns a list of search results.
 
 ```js
 fuse.search(/* pattern , options*/)


### PR DESCRIPTION
Problem:
https://fusejs.io/api/methods.html

![image](https://user-images.githubusercontent.com/1531591/99706735-1d7f2c00-2a61-11eb-8858-ff74a675e7e2.png)

Just was reading through and thought I'd fix a typo