### PR TITLE
fix(typescript): add config declaration to types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -287,4 +287,6 @@ declare namespace Fuse {
       }
     | { $and?: Expression[] }
     | { $or?: Expression[] }
+   
+  export const config: Required<IFuseOptions<T>>;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -288,5 +288,5 @@ declare namespace Fuse {
     | { $and?: Expression[] }
     | { $or?: Expression[] }
    
-  export const config: Required<IFuseOptions<T>>;
+  export const config: Required<IFuseOptions<any>>;
 }


### PR DESCRIPTION
Fixes #542 

This PR fixes the TypeScript declarations to include the exported config property on Fuse.