### PR TITLE
Declare module as side effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "unpkg": "./dist/fuse.js",
   "jsdelivr": "./dist/fuse.js",
   "typings": "./dist/fuse.d.ts",
+  "sideEffects": false,
   "files": [
     "dist"
   ],


### PR DESCRIPTION
We're using fuse.js in our UI library that is used across various microfrontend modules. Unfortunately fuse.js doesn't tree-shake away when a module is not using the search part of our UI library. With this change, webpack is able to tree-shake fuse.js successfully.