### PR TITLE
Rollback minimum Node.js version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
     "webpack-cli": "^4.9.1"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=10"
   }
 }


### PR DESCRIPTION
This rolls back the change made in #599 as this is a breaking change.

Fixes #600

@krisk would you be able to release a patch 6.5.1 with this?