### PR TITLE
refactor(options): improve keys option typing

### DIFF
--- a/dist/fuse.d.ts
+++ b/dist/fuse.d.ts
@@ -234,12 +234,12 @@ declare namespace Fuse {
   //   name: 'title',
   //   weight: 0.7
   // }
-  export type FuseOptionKeyObject = {
-    name: string | string[]
+  export type FuseOptionKeyObject<T> = {
+    name: T | T[]
     weight: number
   }
 
-  export type FuseOptionKey = FuseOptionKeyObject | string | string[]
+  export type FuseOptionKey<T = string> = FuseOptionKeyObject<T> | T | T[]
 
   export interface IFuseOptions<T> {
     isCaseSensitive?: boolean
@@ -250,7 +250,7 @@ declare namespace Fuse {
     ignoreFieldNorm?: boolean
     includeMatches?: boolean
     includeScore?: boolean
-    keys?: Array<FuseOptionKey>
+    keys?: Array<FuseOptionKey<keyof T>>
     location?: number
     minMatchCharLength?: number
     shouldSort?: boolean

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -231,12 +231,12 @@ declare namespace Fuse {
   //   name: 'title',
   //   weight: 0.7
   // }
-  export type FuseOptionKeyObject = {
-    name: string | string[]
+  export type FuseOptionKeyObject<T> = {
+    name: T | T[]
     weight: number
   }
 
-  export type FuseOptionKey = FuseOptionKeyObject | string | string[]
+  export type FuseOptionKey<T = string> = FuseOptionKeyObject<T> | T | T[]
 
   export interface IFuseOptions<T> {
     isCaseSensitive?: boolean
@@ -247,7 +247,7 @@ declare namespace Fuse {
     ignoreFieldNorm?: boolean
     includeMatches?: boolean
     includeScore?: boolean
-    keys?: Array<FuseOptionKey>
+    keys?: Array<FuseOptionKey<keyof T>>
     location?: number
     minMatchCharLength?: number
     shouldSort?: boolean


### PR DESCRIPTION
Make keys typing more precise, allow only existing object keys.
The change is already covered by typing.tests.ts and pass all tests.