### PR TITLE
feat: allow to pass a getFn for a specific key

### DIFF
--- a/src/tools/FuseIndex.js
+++ b/src/tools/FuseIndex.js
@@ -92,7 +92,7 @@ export default class FuseIndex {
     // Iterate over every key (i.e, path), and fetch the value at that key
     this.keys.forEach((key, keyIndex) => {
       // console.log(key)
-      let value = this.getFn(doc, key.path)
+      let value = key.getFn ? key.getFn(doc) : this.getFn(doc, key.path)
 
       if (!isDefined(value)) {
         return

--- a/src/tools/KeyStore.js
+++ b/src/tools/KeyStore.js
@@ -67,7 +67,7 @@ export function createKey(key) {
     id = createKeyId(name)
   }
 
-  return { path, id, weight, src }
+  return { path, id, weight, src, getFn: key.getFn }
 }
 
 export function createKeyPath(key) {

--- a/test/indexing.test.js
+++ b/test/indexing.test.js
@@ -65,11 +65,11 @@ describe('Searching', () => {
       includeScore: true,
       threshold: 0.3,
       keys: [
-        { name: 'title', getFn: (book) => book.title },
+        { name: 'bookTitle', getFn: (book) => book.title },
         { name: 'authorName', getFn: (book) => book.author.firstName }
       ]
     })
-    const result = fuse.search({ title: 'old man' })
+    const result = fuse.search({ bookTitle: 'old man' })
     expect(result.length).toBe(1)
     expect(idx(result)).toMatchObject([0])
   })

--- a/test/indexing.test.js
+++ b/test/indexing.test.js
@@ -29,6 +29,18 @@ describe('Searching', () => {
     expect(myIndex.keys).toBeDefined()
   })
 
+  test('createIndex: ensure keys can be created with getFn', () => {
+    let myIndex = Fuse.createIndex(
+      [
+        { name: 'title', getFn: (book) => book.title },
+        { name: 'author.firstName', getFn: (book) => book.author.firstName }
+      ],
+      Books
+    )
+    expect(myIndex.records).toBeDefined()
+    expect(myIndex.keys).toBeDefined()
+  })
+
   test('parseIndex: ensure index can be exported and Fuse can be initialized', () => {
     const myIndex = Fuse.createIndex(options.keys, Books)
     expect(myIndex.size()).toBe(Books.length)
@@ -41,6 +53,22 @@ describe('Searching', () => {
     expect(parsedIndex.size()).toBe(Books.length)
 
     const fuse = new Fuse(Books, options, parsedIndex)
+    const result = fuse.search({ title: 'old man' })
+    expect(result.length).toBe(1)
+    expect(idx(result)).toMatchObject([0])
+  })
+
+  test('parseIndex: search with getFn', () => {
+    const fuse = new Fuse(Books, {
+      useExtendedSearch: true,
+      includeMatches: true,
+      includeScore: true,
+      threshold: 0.3,
+      keys: [
+        { name: 'title', getFn: (book) => book.title },
+        { name: 'authorName', getFn: (book) => book.author.firstName }
+      ]
+    })
     const result = fuse.search({ title: 'old man' })
     expect(result.length).toBe(1)
     expect(idx(result)).toMatchObject([0])


### PR DESCRIPTION
This PR introduces the following

```js
const fuse = new Fuse(Books, {
  useExtendedSearch: true,
  includeMatches: true,
  includeScore: true,
  threshold: 0.3,
  keys: [
    { name: "title", getFn: (book) => book.title },
    { name: "authorName", getFn: (book) => book.author.firstName },
  ],
});
const result = fuse.search({ title: "old man" });
```

I noticed it has been requested [several](https://github.com/krisk/Fuse/issues/99) [times](https://github.com/krisk/Fuse/issues/313)

Let me know if any other changes are necessary before merging