### PR TITLE
Include `undefined` in `location` documentation

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -64,10 +64,10 @@ You shouldn't have to change these.
 
 ### `location`
 
-- Type: `number`
-- Default: `0`
+- Type: `number | undefined`
+- Default: `undefined`
 
-Determines approximately where in the text is the pattern expected to be found.
+Determines approximately where in the text is the pattern expected to be found. Defaults to `undefined` which ignores the location of the pattern in the string.
 
 ### `threshold`
 


### PR DESCRIPTION
First off, thanks so much for this wonderful library!

I've just used in recently in a project and I noticed that `location` seems to default to `undefined` which goes against what the docs currently state so here's my request to update the docs :)

(unless you tell me the expected behaviour should actually default to `0` in which case I guess the change should be done in the actual code rather than the docs, but this defaulting to `undefined` seems pretty sensible to me)