### PR TITLE
fix: excessive splitting in parseQuery

### DIFF
--- a/src/search/extended/parseQuery.js
+++ b/src/search/extended/parseQuery.js
@@ -22,7 +22,7 @@ const searchers = [
 const searchersLen = searchers.length
 
 // Regex to split by spaces, but keep anything in quotes together
-const SPACE_RE = / +(?=([^\"]*\"[^\"]*\")*[^\"]*$)/
+const SPACE_RE = / +(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/
 const OR_TOKEN = '|'
 
 // Return a 2D array representation of the query, for simpler parsing.


### PR DESCRIPTION
The regexp is correct, but produces extraneous results unless the group is made nameless:

With this change:
```js
'"123" "456"'.split(
  / +(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/
)
// [ '"123"', '"456"' ]
```

Without this change:
```js
'"123" "456"'.split(
  / +(?=([^\"]*\"[^\"]*\")*[^\"]*$)/
)
// [ '"123"', '"456"', '"456"' ]
```