### PR TITLE
fix(typescript): `fieldNormWeight` should be optional, fixes #650

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -252,7 +252,7 @@ declare namespace Fuse {
     /** When `true`, the calculation for the relevance score (used for sorting) will ignore the `field-length norm`. */
     ignoreFieldNorm?: boolean
     /** Determines how much the `field-length norm` affects scoring. A value of `0` is equivalent to ignoring the field-length norm. A value of `0.5` will greatly reduce the effect of field-length norm, while a value of `2.0` will greatly increase it. */
-    fieldNormWeight: number
+    fieldNormWeight?: number
     /** Whether the matches should be included in the result set. When `true`, each record in the result set will include the indices of the matched characters. These can consequently be used for highlighting purposes. */
     includeMatches?: boolean
     /** Whether the score should be included in the result set. A score of `0`indicates a perfect match, while a score of `1` indicates a complete mismatch. */


### PR DESCRIPTION
The `fieldNormWeight` config option has a default value of `1`, and can therefore be optional (like the other config options)

https://github.com/krisk/Fuse/blob/a9e00804497a1bfd7a94040520417825c085c945/src/core/config.js#L58-L59

### Related issues
- Fixes #650 

### Was this a regression?
- Omitting `fieldNormWeight` was valid in <= 6.5.3 (though only because it was missing from the type definition), and is now unnecessarily required in 6.6.0