### PR TITLE
feat: refine type includeMatches and includeScore

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -177,7 +177,7 @@ const options = {
     { name: 'title', getFn: (book) => book.title },
     { name: 'authorName', getFn: (book) => book.author.name }
   ]
-})
+}
 
 const fuse = new Fuse(list, options)
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,10 +1,10 @@
 export default Fuse
 export as namespace Fuse
 
-declare class Fuse<T> {
+declare class Fuse<T, OP extends Fuse.IFuseOptions<T>> {
   constructor(
     list: ReadonlyArray<T>,
-    options?: Fuse.IFuseOptions<T>,
+    options?: OP,
     index?: Fuse.FuseIndex<T>
   )
   /**
@@ -28,7 +28,7 @@ declare class Fuse<T> {
   search<R = T>(
     pattern: string | Fuse.Expression,
     options?: Fuse.FuseSearchOptions
-  ): Fuse.FuseResult<R>[]
+  ): Fuse.FuseResult<R, OP>[]
 
   setCollection(docs: ReadonlyArray<T>, index?: Fuse.FuseIndex<T>): void
 
@@ -290,12 +290,15 @@ declare namespace Fuse {
     limit: number
   }
 
-  export type FuseResult<T> = {
+  export type FuseResult<T, O extends Fuse.IFuseOptions<any>> = {
     item: T
     refIndex: number
-    score?: number
-    matches?: ReadonlyArray<FuseResultMatch>
-  }
+  } & (O['includeMatches'] extends true
+    ? { matches: ReadonlyArray<FuseResultMatch> }
+    : {}) &
+    (O['includeScore'] extends true
+      ? { score: number }
+      : {})
 
   export type Expression =
     | { [key: string]: string }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,7 @@
 export default Fuse
 export as namespace Fuse
 
-declare class Fuse<T, OP extends Fuse.IFuseOptions<T>> {
+declare class Fuse<T, OP extends Fuse.IFuseOptions<T> = {}> {
   constructor(
     list: ReadonlyArray<T>,
     options?: OP,


### PR DESCRIPTION
For better type infer

```ts
const data = [{ id: '1' }]
{
  const fuse = new Fuse(data, {
    keys: ['id'],
    includeScore: true
  })
  const r = fuse.search('1')

  // ok
  r.sort((a, b) => a.score - b.score)
}
{
  const fuse = new Fuse(data, {
    keys: ['id']
  })
  const r = fuse.search('1')

  //  error: Property 'score' does not exist on type '{ item: { id: string; }; refIndex: number; }'
  r.sort((a, b) => a.score - b.score)
}

{
  const fuse = new Fuse(data, {
    keys: ['id'],
    includeMatches: true
  })
  const r = fuse.search('1')

  // ok
  r.sort((a, b) => a.matches.length - b.matches.length)
}

{
  const fuse = new Fuse(data, {
    keys: ['id'],
    includeMatches: false
  })
  const r = fuse.search('1')

  // error: Property 'matches' does not exist on type '{ item: { id: string; }; refIndex: number; }'.
  r.sort((a, b) => a.matches.length - b.matches.length)
}
```