### PR TITLE
fix: FuseSortFunctionMatch typescript types

### DIFF
--- a/dist/fuse.d.ts
+++ b/dist/fuse.d.ts
@@ -148,9 +148,15 @@ declare namespace Fuse {
   // }
   export type FuseSortFunctionMatch = {
     score: number
-    key: string
+    key: {
+      path: string[]
+      id: string
+      weight: number
+      src: string
+    }
+    norm: number
     value: string
-    indices: ReadonlyArray<number>[]
+    indices?: ReadonlyArray<number>[]
   }
 
   // {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -145,9 +145,15 @@ declare namespace Fuse {
   // }
   export type FuseSortFunctionMatch = {
     score: number
-    key: string
+    key: {
+      path: string[]
+      id: string
+      weight: number
+      src: string
+    }
+    norm: number
     value: string
-    indices: ReadonlyArray<number>[]
+    indices?: ReadonlyArray<number>[]
   }
 
   // {

--- a/test/typings.test.ts
+++ b/test/typings.test.ts
@@ -103,3 +103,73 @@ describe('Logical search results', () => {
     expect(idx(result)).toMatchObject([0])
   })
 })
+
+describe('FuseSortFunctionMatch', () => {
+  type Foo = { foo: string }
+  const list: Array<Foo> = [
+    {
+      foo: 'foo'
+    },
+    {
+      foo: 'bar'
+    },
+    {
+      foo: 'baz'
+    }
+  ]
+
+  test('without includeMatches', () => {
+    let sortFnCalled = false
+    const options: Fuse.IFuseOptions<Foo> = {
+      keys: ['foo'],
+      sortFn: (a, b) => {
+        sortFnCalled = true
+        ;[a, b].forEach((c) => {
+          expect(c.idx).toBeDefined()
+          expect(c.item).toBeDefined()
+          expect(c.matches).toBeDefined()
+          expect(c.score).toBeDefined()
+          c.matches.forEach((m) => {
+            expect(m.indices).toBeUndefined()
+            expect(m.key).toBeDefined()
+            expect(m.norm).toBeDefined()
+            expect(m.value).toBeDefined()
+            expect(m.score).toBeDefined()
+          })
+        })
+        return 1
+      }
+    }
+    const fuse = new Fuse(list, options)
+    fuse.search('ba')
+    expect(sortFnCalled).toEqual(true)
+  })
+
+  test('with includeMatches', () => {
+    let sortFnCalled = false
+    const options: Fuse.IFuseOptions<Foo> = {
+      keys: ['foo'],
+      includeMatches: true,
+      sortFn: (a, b) => {
+        sortFnCalled = true
+        ;[a, b].forEach((c) => {
+          expect(c.idx).toBeDefined()
+          expect(c.item).toBeDefined()
+          expect(c.matches).toBeDefined()
+          expect(c.score).toBeDefined()
+          c.matches.forEach((m) => {
+            expect(m.indices).toBeDefined()
+            expect(m.key).toBeDefined()
+            expect(m.norm).toBeDefined()
+            expect(m.value).toBeDefined()
+            expect(m.score).toBeDefined()
+          })
+        })
+        return 1
+      }
+    }
+    const fuse = new Fuse(list, options)
+    fuse.search('ba')
+    expect(sortFnCalled).toEqual(true)
+  })
+})


### PR DESCRIPTION
Relates to #613 

Fixes typing on `FuseSortFunctionMatch`, mainly on `key` & `indices` attribute.
I included typings test which triggers `searchFn` with and without `includeMatches` option, which when undefined, the `indices` attribute type is also undefined.
I am not sure if this change should bring any side effects, or if the typing on `FuseSortFunctionMatch` should be different when Fuse constructor is given different option combinations from the ones in the added tests. 