### PR TITLE
fix: double totalWeight

### DIFF
--- a/src/tools/KeyStore.js
+++ b/src/tools/KeyStore.js
@@ -13,8 +13,6 @@ export default class KeyStore {
     keys.forEach((key) => {
       let obj = createKey(key)
 
-      totalWeight += obj.weight
-
       this._keys.push(obj)
       this._keyMap[obj.id] = obj
 


### PR DESCRIPTION
We call `totalWeight += obj.weight` two times, so the `totalWeight` is double