### PR TITLE
Allow quoted searches containing newlines

### DIFF
--- a/src/search/extended/ExactMatch.js
+++ b/src/search/extended/ExactMatch.js
@@ -12,7 +12,7 @@ export default class ExactMatch extends BaseMatch {
     return 'exact'
   }
   static get multiRegex() {
-    return /^="(.*)"$/
+    return /^="(.*)"$/s
   }
   static get singleRegex() {
     return /^=(.*)$/

--- a/src/search/extended/FuzzyMatch.js
+++ b/src/search/extended/FuzzyMatch.js
@@ -32,7 +32,7 @@ export default class FuzzyMatch extends BaseMatch {
     return 'fuzzy'
   }
   static get multiRegex() {
-    return /^"(.*)"$/
+    return /^"(.*)"$/s
   }
   static get singleRegex() {
     return /^(.*)$/

--- a/src/search/extended/IncludeMatch.js
+++ b/src/search/extended/IncludeMatch.js
@@ -12,7 +12,7 @@ export default class IncludeMatch extends BaseMatch {
     return 'include'
   }
   static get multiRegex() {
-    return /^'"(.*)"$/
+    return /^'"(.*)"$/s
   }
   static get singleRegex() {
     return /^'(.*)$/

--- a/src/search/extended/InverseExactMatch.js
+++ b/src/search/extended/InverseExactMatch.js
@@ -12,7 +12,7 @@ export default class InverseExactMatch extends BaseMatch {
     return 'inverse-exact'
   }
   static get multiRegex() {
-    return /^!"(.*)"$/
+    return /^!"(.*)"$/s
   }
   static get singleRegex() {
     return /^!(.*)$/

--- a/src/search/extended/InversePrefixExactMatch.js
+++ b/src/search/extended/InversePrefixExactMatch.js
@@ -12,7 +12,7 @@ export default class InversePrefixExactMatch extends BaseMatch {
     return 'inverse-prefix-exact'
   }
   static get multiRegex() {
-    return /^!\^"(.*)"$/
+    return /^!\^"(.*)"$/s
   }
   static get singleRegex() {
     return /^!\^(.*)$/

--- a/src/search/extended/InverseSuffixExactMatch.js
+++ b/src/search/extended/InverseSuffixExactMatch.js
@@ -11,7 +11,7 @@ export default class InverseSuffixExactMatch extends BaseMatch {
     return 'inverse-suffix-exact'
   }
   static get multiRegex() {
-    return /^!"(.*)"\$$/
+    return /^!"(.*)"\$$/s
   }
   static get singleRegex() {
     return /^!(.*)\$$/

--- a/src/search/extended/PrefixExactMatch.js
+++ b/src/search/extended/PrefixExactMatch.js
@@ -11,7 +11,7 @@ export default class PrefixExactMatch extends BaseMatch {
     return 'prefix-exact'
   }
   static get multiRegex() {
-    return /^\^"(.*)"$/
+    return /^\^"(.*)"$/s
   }
   static get singleRegex() {
     return /^\^(.*)$/

--- a/src/search/extended/SuffixExactMatch.js
+++ b/src/search/extended/SuffixExactMatch.js
@@ -11,7 +11,7 @@ export default class SuffixExactMatch extends BaseMatch {
     return 'suffix-exact'
   }
   static get multiRegex() {
-    return /^"(.*)"\$$/
+    return /^"(.*)"\$$/s
   }
   static get singleRegex() {
     return /^(.*)\$$/

--- a/test/__snapshots__/extended-search.test.js.snap
+++ b/test/__snapshots__/extended-search.test.js.snap
@@ -50,6 +50,31 @@ Array [
   },
   Object {
     "item": Object {
+      "text": "multiline
+text",
+    },
+    "matches": Array [
+      Object {
+        "indices": Array [
+          Array [
+            0,
+            13,
+          ],
+          Array [
+            0,
+            13,
+          ],
+        ],
+        "key": "text",
+        "value": "multiline
+text",
+      },
+    ],
+    "refIndex": 6,
+    "score": 2.220446049250313e-16,
+  },
+  Object {
+    "item": Object {
       "text": "hello word",
     },
     "matches": Array [
@@ -206,6 +231,27 @@ Array [
   },
   Object {
     "item": Object {
+      "text": "multiline
+text",
+    },
+    "matches": Array [
+      Object {
+        "indices": Array [
+          Array [
+            0,
+            13,
+          ],
+        ],
+        "key": "text",
+        "value": "multiline
+text",
+      },
+    ],
+    "refIndex": 6,
+    "score": 2.220446049250313e-16,
+  },
+  Object {
+    "item": Object {
       "text": "hello word",
     },
     "matches": Array [
@@ -306,6 +352,27 @@ Array [
   },
   Object {
     "item": Object {
+      "text": "multiline
+text",
+    },
+    "matches": Array [
+      Object {
+        "indices": Array [
+          Array [
+            0,
+            13,
+          ],
+        ],
+        "key": "text",
+        "value": "multiline
+text",
+      },
+    ],
+    "refIndex": 6,
+    "score": 2.220446049250313e-16,
+  },
+  Object {
+    "item": Object {
       "text": "how are you",
     },
     "matches": Array [
@@ -402,6 +469,27 @@ Array [
       },
     ],
     "refIndex": 5,
+    "score": 2.220446049250313e-16,
+  },
+  Object {
+    "item": Object {
+      "text": "multiline
+text",
+    },
+    "matches": Array [
+      Object {
+        "indices": Array [
+          Array [
+            0,
+            13,
+          ],
+        ],
+        "key": "text",
+        "value": "multiline
+text",
+      },
+    ],
+    "refIndex": 6,
     "score": 2.220446049250313e-16,
   },
   Object {
@@ -602,6 +690,32 @@ Array [
     ],
     "refIndex": 2,
     "score": 1.4901161193847656e-8,
+  },
+]
+`;
+
+exports[`Searching using extended search Search: single literal match with newline 1`] = `
+Array [
+  Object {
+    "item": Object {
+      "text": "multiline
+text",
+    },
+    "matches": Array [
+      Object {
+        "indices": Array [
+          Array [
+            0,
+            13,
+          ],
+        ],
+        "key": "text",
+        "value": "multiline
+text",
+      },
+    ],
+    "refIndex": 6,
+    "score": 2.220446049250313e-16,
   },
 ]
 `;

--- a/test/extended-search.test.js
+++ b/test/extended-search.test.js
@@ -19,6 +19,9 @@ describe('Searching using extended search', () => {
     },
     {
       text: 'smith'
+    },
+    {
+      text: 'multiline\ntext'
     }
   ]
 
@@ -86,6 +89,12 @@ describe('Searching using extended search', () => {
     let result = fuse.search('\'"indeed fine" foo$ | helol')
     expect(result).toMatchSnapshot()
   })
+
+  test('Search: single literal match with newline', () => {
+    let result = fuse.search('\'"multiline\ntext"')
+    expect(result).toMatchSnapshot()
+  })
+
 })
 
 describe('ignoreLocation when useExtendedSearch is true', () => {


### PR DESCRIPTION
Fixes https://github.com/krisk/Fuse/issues/696

The `multiRegex` values were not matching newlines because `.` in a regex doesn't match newlines by default. Adding `/s` makes the `.` match them.

Added a new test.