### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ When creating issues, it's important to follow common guidelines to make them ex
 
 - [GitHub Guides: Mastering Issues](https://guides.github.com/features/issues/)
 - [Wiredcraft: How We Write Github Issues](https://wiredcraft.com/blog/how-we-write-our-github-issues/)
-- [NYC Planning Digital: Writing Useful Github Issues](https://medium.com/nyc-planning-digital/writing-a-proper-github-issue-97427d62a20f)
+- [NYC Planning Digital: Writing a proper GitHub issue](https://medium.com/nyc-planning-digital/writing-a-proper-github-issue-97427d62a20f)
 
 ## <a name="submit-pr"></a> Pull Request Submission Guidelines
 

--- a/docs/.vuepress/components/Team/Team.vue
+++ b/docs/.vuepress/components/Team/Team.vue
@@ -59,7 +59,7 @@
               :href="githubUrl(profile.social.github)"
             >
               <i class="fab fa-github"></i>
-              <span class="sr-only">Github</span>
+              <span class="sr-only">GitHub</span>
             </a>
             <a
               class="twitter"

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -375,7 +375,7 @@ nav.nav-links div:nth-child(3) a {
   padding-left: 30px;  /* width of the image plus a little extra padding */
 }
 
-// Github
+// GitHub
 nav.nav-links div:nth-child(4) a {
   background-image: url(/assets/img/github.svg);
   background-repeat: no-repeat;

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ Of course! Fuse.js has no DOM dependencies.
 
 ### Who's using Fuse.js these days?
 
-Plenty of people. It's hard to say an exact number, since it's free. But a good indication is the number of [dependents](https://www.npmjs.com/package/fuse.js?activeTab=dependents) on NPM, and the [dependency graph](https://github.com/krisk/Fuse/network/dependents) and [stargazers](https://github.com/krisk/Fuse/stargazers) on Github.
+Plenty of people. It's hard to say an exact number, since it's free. But a good indication is the number of [dependents](https://www.npmjs.com/package/fuse.js?activeTab=dependents) on npm, and the [dependency graph](https://github.com/krisk/Fuse/network/dependents) and [stargazers](https://github.com/krisk/Fuse/stargazers) on GitHub.
 
 ---
 

--- a/docs/getting-started/different-builds.md
+++ b/docs/getting-started/different-builds.md
@@ -1,6 +1,6 @@
 # Explanation of Different Builds
 
-In the [`dist/` directory of the NPM package](https://cdn.jsdelivr.net/npm/fuse.js/dist/) you will find many different builds of Fuse.js. Here's an overview of the difference between them.
+In the [`dist/` directory of the npm package](https://cdn.jsdelivr.net/npm/fuse.js/dist/) you will find many different builds of Fuse.js. Here's an overview of the difference between them.
 
 |                        | UMD               | CommonJS             | ES Module (for bundlers) |
 | ---------------------- | ----------------- | -------------------- | ------------------------ |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,7 +2,7 @@
 
 Latest stable version: **{{ $themeConfig.version }}**
 
-### NPM
+### npm
 
 ```sh
 $ npm install --save fuse.js
@@ -54,7 +54,7 @@ If you are using native ES Modules, there is also an ES Modules compatible build
 </script>
 ```
 
-You can browse the source of the NPM package at [cdn.jsdelivr.net/npm/fuse.js](https://cdn.jsdelivr.net/npm/fuse.js).
+You can browse the source of the npm package at [cdn.jsdelivr.net/npm/fuse.js](https://cdn.jsdelivr.net/npm/fuse.js).
 
 Fuse.js is also available on [unpkg](https://unpkg.com/fuse.js).
 


### PR DESCRIPTION
Just a few minor capitalization fixes: `Github` -> `GitHub`, `NPM` -> `npm`

npm should never be capitalized:
https://github.com/npm/cli#is-it-npm-or-npm-or-npm