### PR TITLE
Fix incorrect default export in TS declaration file

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-export default Fuse
+export = Fuse
 export as namespace Fuse
 
 declare class Fuse<T> {


### PR DESCRIPTION
The TS declaration file is loaded by TypeScript in the `"typings"` field of package.json. This field corresponds to the `"main"` field, which is set to `./dist/fuse.common.js`, which [does](https://github.com/krisk/Fuse/blob/f507e9f19ff022c13e4517ecff3e7a72ee2688ee/dist/fuse.common.js#L2004C1-L2004C23)

```js
module.exports = Fuse;
```

The correct TS representation of `module.exports = Fuse` is `export = Fuse`, not `export default Fuse`.

This is the root cause of many previous reports:

- #679
- #541
- #422

and was brought to my attention at https://github.com/microsoft/TypeScript/issues/50058#issuecomment-1644335391.

You can see the bug is also detected at https://arethetypeswrong.github.io/?p=fuse.js%406.6.2. Explainer: https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseExportDefault.md.

Note also:
- This change allows users to import Fuse whether they have `esModuleInterop` set or not. While TS users _should_ always set that option, when they _have_ to in order to use a library, it always indicates that the library is misconfigured. It’s never a correct solution for a library to require TS users to set that option one way or another.
- `esModuleInterop` is irrelevant for users who are importing Fuse from a true ES module, as was attempted in #679 and https://github.com/microsoft/TypeScript/issues/50058#issuecomment-1644335391. Those users are completely unable to import Fuse without compiler errors without this PR, regardless of whether they set `esModuleInterop`.

I’ve thrown a lot of information at you, but I’m happy to answer any questions or concerns you may have!