### PR TITLE
Clarify input to Fuse.parseIndex

### DIFF
--- a/docs/api/indexing.md
+++ b/docs/api/indexing.md
@@ -55,7 +55,7 @@ Fuse will automatically index the table if one isn't provided during instantiati
 
 ### `Fuse.parseIndex`
 
-Parses a serialized Fuse index.
+Parses a serialized Fuse index from a json object representation.
 
 **Example**
 
@@ -69,6 +69,9 @@ fs.writeFile('fuse-index.json', JSON.stringify(myIndex.toJSON()))
 // (2) When app starts
 // Load and deserialize index
 const fuseIndex = await require('fuse-index.json')
+// Alternatively, if fetching the index, convert to json before parsing.
+const fuseIndex = await fetch('./fuse-index.json').then(r => r.json())
+
 const myIndex = Fuse.parseIndex(fuseIndex)
 // initialize Fuse with the index
 const fuse = new Fuse(books, options, myIndex)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -91,7 +91,10 @@ declare class Fuse<T> {
   ): FuseIndex<U>
 
   public static parseIndex<U>(
-    index: any,
+    index: {
+      keys: ReadonlyArray<string>
+      records: FuseIndexRecords
+    },
     options?: FuseIndexOptions<U>
   ): FuseIndex<U>
 


### PR DESCRIPTION
It is not obvious how to use `Fuse.parseInput`, and if supplied an incorrect argument it errs, silently.

1. Narrowing the type clarifies intent (in code and in editor integrations).
2. Documentation gives a further clarifying example.

This fixes the issues that led to #524 and #624 and my losing more time than I'd have liked on this otherwise excellent library!

~~I'm Creating as a draft because it doesn't yet meet contributing guidelines.~~