### PR TITLE
fix: patch `key` type for `matches` in `sortFn`

### DIFF
--- a/dist/fuse.d.ts
+++ b/dist/fuse.d.ts
@@ -145,6 +145,14 @@ type FuseSortFunctionItem = {
   [key: string]: { $: string } | { $: string; idx: number }[]
 }
 
+type FuseSortFunctionMatchKey<T = unknown> = {
+  path: string[]
+  id: string
+  weight: number
+  src: string | string[]
+  getFn: FuseOptionKeyObject<T>['getFn']
+}
+
 /**
  * @example
  * ```ts
@@ -156,9 +164,9 @@ type FuseSortFunctionItem = {
  * }
  * ```
  */
-type FuseSortFunctionMatch = {
+type FuseSortFunctionMatch<T = unknown> = {
   score: number
-  key: string
+  key: FuseSortFunctionMatchKey<T>
   value: string
   indices: ReadonlyArray<number>[]
 }
@@ -175,20 +183,21 @@ type FuseSortFunctionMatch = {
  * }
  * ```
  */
-type FuseSortFunctionMatchList = FuseSortFunctionMatch & {
-  idx: number
-}
+type FuseSortFunctionMatchList<T = unknown> =
+  FuseSortFunctionMatch<T> & {
+    idx: number
+  }
 
-type FuseSortFunctionArg = {
+type FuseSortFunctionArg<T = unknown> = {
   idx: number
   item: FuseSortFunctionItem
   score: number
-  matches?: (FuseSortFunctionMatch | FuseSortFunctionMatchList)[]
+  matches?: (FuseSortFunctionMatch<T> | FuseSortFunctionMatchList<T>)[]
 }
 
-type FuseSortFunction = (
-  a: FuseSortFunctionArg,
-  b: FuseSortFunctionArg
+type FuseSortFunction<T = unknown> = (
+  a: FuseSortFunctionArg<T>,
+  b: FuseSortFunctionArg<T>
 ) => number
 
 /**
@@ -322,7 +331,7 @@ interface IFuseOptions<T> {
   /** Whether to sort the result list, by score. */
   shouldSort?: boolean
   /** The function to use to sort all the results. The default will sort by ascending relevance score, ascending index. */
-  sortFn?: FuseSortFunction
+  sortFn?: FuseSortFunction<T>
   /** At what point does the match algorithm give up. A threshold of `0.0` requires a perfect match (of both letters and location), a threshold of `1.0` would match anything. */
   threshold?: number
   /** When `true`, it enables the use of unix-like search commands. See [example](/examples.html#extended-search). */
@@ -370,4 +379,4 @@ type Expression =
   | { $and?: Expression[] }
   | { $or?: Expression[] }
 
-export { Expression, FuseGetFunction, FuseIndex, FuseIndexObjectRecord, FuseIndexOptions, FuseIndexRecords, FuseIndexStringRecord, FuseOptionKey, FuseOptionKeyObject, FuseResult, FuseResultMatch, FuseSearchOptions, FuseSortFunction, FuseSortFunctionArg, FuseSortFunctionItem, FuseSortFunctionMatch, FuseSortFunctionMatchList, IFuseOptions, RangeTuple, RecordEntry, RecordEntryArrayItem, RecordEntryObject, Fuse as default };
+export { Expression, FuseGetFunction, FuseIndex, FuseIndexObjectRecord, FuseIndexOptions, FuseIndexRecords, FuseIndexStringRecord, FuseOptionKey, FuseOptionKeyObject, FuseResult, FuseResultMatch, FuseSearchOptions, FuseSortFunction, FuseSortFunctionArg, FuseSortFunctionItem, FuseSortFunctionMatch, FuseSortFunctionMatchKey, FuseSortFunctionMatchList, IFuseOptions, RangeTuple, RecordEntry, RecordEntryArrayItem, RecordEntryObject, Fuse as default };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -145,6 +145,14 @@ export type FuseSortFunctionItem = {
   [key: string]: { $: string } | { $: string; idx: number }[]
 }
 
+export type FuseSortFunctionMatchKey<T = unknown> = {
+  path: string[]
+  id: string
+  weight: number
+  src: string | string[]
+  getFn: FuseOptionKeyObject<T>['getFn']
+}
+
 /**
  * @example
  * ```ts
@@ -156,9 +164,9 @@ export type FuseSortFunctionItem = {
  * }
  * ```
  */
-export type FuseSortFunctionMatch = {
+export type FuseSortFunctionMatch<T = unknown> = {
   score: number
-  key: string
+  key: FuseSortFunctionMatchKey<T>
   value: string
   indices: ReadonlyArray<number>[]
 }
@@ -175,20 +183,21 @@ export type FuseSortFunctionMatch = {
  * }
  * ```
  */
-export type FuseSortFunctionMatchList = FuseSortFunctionMatch & {
-  idx: number
-}
+export type FuseSortFunctionMatchList<T = unknown> =
+  FuseSortFunctionMatch<T> & {
+    idx: number
+  }
 
-export type FuseSortFunctionArg = {
+export type FuseSortFunctionArg<T = unknown> = {
   idx: number
   item: FuseSortFunctionItem
   score: number
-  matches?: (FuseSortFunctionMatch | FuseSortFunctionMatchList)[]
+  matches?: (FuseSortFunctionMatch<T> | FuseSortFunctionMatchList<T>)[]
 }
 
-export type FuseSortFunction = (
-  a: FuseSortFunctionArg,
-  b: FuseSortFunctionArg
+export type FuseSortFunction<T = unknown> = (
+  a: FuseSortFunctionArg<T>,
+  b: FuseSortFunctionArg<T>
 ) => number
 
 /**
@@ -322,7 +331,7 @@ export interface IFuseOptions<T> {
   /** Whether to sort the result list, by score. */
   shouldSort?: boolean
   /** The function to use to sort all the results. The default will sort by ascending relevance score, ascending index. */
-  sortFn?: FuseSortFunction
+  sortFn?: FuseSortFunction<T>
   /** At what point does the match algorithm give up. A threshold of `0.0` requires a perfect match (of both letters and location), a threshold of `1.0` would match anything. */
   threshold?: number
   /** When `true`, it enables the use of unix-like search commands. See [example](/examples.html#extended-search). */


### PR DESCRIPTION
Patch the `key` type for `matches` in `sortFn` arguments.

closes #811 